### PR TITLE
Fix broken deployment guide link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -15,7 +15,7 @@ The goal of the EOEPCA's “Common Architecture” is therefore to define and ag
 
 System...
 * [**EOEPCA Release v1.4** - https://github.com/EOEPCA/eoepca/releases/tag/v1.4](https://github.com/EOEPCA/eoepca/releases/tag/v1.4)
-* [**Deployment Guide** - https://deployment-guide.docs.eoepca.org/v1.4/](https://deployment-guide.docs.eoepca.org/v1.4/)
+* [**Deployment Guide (latest)** - https://eoepca.readthedocs.io/projects/deploy/en/latest/](https://eoepca.readthedocs.io/projects/deploy/en/latest/)
 * [**Helm Charts** - https://eoepca.github.io/helm-charts](https://eoepca.github.io/helm-charts) [\[sources\]](https://github.com/EOEPCA/helm-charts)
 
 Building Blocks...


### PR DESCRIPTION
Fix broken link to deployment guide and point to latest version of the guide.
I understand the "latest" version of the guide still point to EOEPCA release 1.4 but contains all the fixes after the last release. It is the version we tested on ESA Cloud...